### PR TITLE
Centralize common utils

### DIFF
--- a/lib/core/widgets/document_card.dart
+++ b/lib/core/widgets/document_card.dart
@@ -3,6 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:docudex/data/models/document.dart';
 import 'package:docudex/utils/document_utils.dart';
+import 'package:docudex/utils/app_utils.dart';
 
 class DocumentCard extends StatelessWidget {
   final Document document;
@@ -23,7 +24,7 @@ class DocumentCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final urgencyColor = getUrgencyColor(document.date);
-    final borderColor = Color(int.parse(categoryColor.replaceFirst('#', '0xff')));
+    final borderColor = hexToColor(categoryColor);
     final icon = iconFromCodePoint(categoryIcon);
 
     return Card(

--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import '../data/models/category.dart';
 import '../database/database_helper.dart';
+import '../utils/app_utils.dart';
 
 class CategoryManagementScreen extends StatefulWidget {
   const CategoryManagementScreen({super.key});
@@ -123,9 +124,6 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen> {
     }
   }
 
-  IconData _iconFromCodePoint(String codePoint) {
-    return IconData(int.parse(codePoint), fontFamily: 'MaterialIcons');
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -135,8 +133,8 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen> {
         itemCount: categories.length,
         itemBuilder: (context, index) {
           final cat = categories[index];
-          final color = Color(int.parse(cat.colorHex.replaceFirst('#', '0xff')));
-          final icon = _iconFromCodePoint(cat.iconName);
+          final color = hexToColor(cat.colorHex);
+          final icon = iconFromCodePoint(cat.iconName);
           return ListTile(
             leading: CircleAvatar(backgroundColor: color, child: Icon(icon, color: Colors.white)),
             title: Text(cat.name),

--- a/lib/screens/document_detail_screen.dart
+++ b/lib/screens/document_detail_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/material.dart';
 import '../data/models/document.dart';
 import '../data/models/category.dart';
 import '../database/database_helper.dart';
+import '../utils/app_utils.dart';
+import '../utils/document_utils.dart';
 import 'add_edit_document_screen.dart';
 
 class DocumentDetailScreen extends StatelessWidget {
@@ -13,27 +15,12 @@ class DocumentDetailScreen extends StatelessWidget {
 
   const DocumentDetailScreen({super.key, required this.document, required this.category});
 
-  IconData _iconFromCodePoint(String codePoint) {
-    return IconData(int.parse(codePoint), fontFamily: 'MaterialIcons');
-  }
-
-  Color _getUrgencyColor(String? dateStr) {
-    if (dateStr == null || dateStr.isEmpty) return Colors.grey;
-    final now = DateTime.now();
-    final date = DateTime.tryParse(dateStr);
-    if (date == null) return Colors.grey;
-
-    final diff = date.difference(now).inDays;
-    if (diff < 0) return Colors.red;
-    if (diff <= 7) return Colors.orange;
-    return Colors.green;
-  }
 
   @override
   Widget build(BuildContext context) {
-    final color = Color(int.parse(category.colorHex.replaceFirst('#', '0xff')));
-    final icon = _iconFromCodePoint(category.iconName);
-    final urgencyColor = _getUrgencyColor(document.date);
+    final color = hexToColor(category.colorHex);
+    final icon = iconFromCodePoint(category.iconName);
+    final urgencyColor = getUrgencyColor(document.date);
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/screens/nfc_scan_screen.dart
+++ b/lib/screens/nfc_scan_screen.dart
@@ -6,6 +6,7 @@ import 'package:ndef/ndef.dart' as ndef;
 import '../data/models/document.dart';
 import '../database/database_helper.dart';
 import '../data/models/category.dart';
+import '../utils/app_utils.dart';
 import 'document_detail_screen.dart';
 
 class NfcScanScreen extends StatefulWidget {
@@ -133,9 +134,9 @@ class _NfcScanScreenState extends State<NfcScanScreen> {
                                 final cat = _getCategory(doc.categoryId);
                                 return ListTile(
                                   leading: CircleAvatar(
-                                    backgroundColor: Color(int.parse(cat.colorHex.replaceFirst('#', '0xff'))),
+                                    backgroundColor: hexToColor(cat.colorHex),
                                     child: Icon(
-                                      IconData(int.parse(cat.iconName), fontFamily: 'MaterialIcons'),
+                                      iconFromCodePoint(cat.iconName),
                                       color: Colors.white,
                                     ),
                                   ),

--- a/lib/utils/app_utils.dart
+++ b/lib/utils/app_utils.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// Converts an icon code point string to [IconData].
+IconData iconFromCodePoint(String code) {
+  return IconData(int.parse(code), fontFamily: 'MaterialIcons');
+}
+
+/// Parses a color hex code like "#ffffff" to a [Color].
+Color hexToColor(String hex) {
+  return Color(int.parse(hex.replaceFirst('#', '0xff')));
+}

--- a/lib/utils/document_utils.dart
+++ b/lib/utils/document_utils.dart
@@ -15,7 +15,3 @@ Color getUrgencyColor(String? dateStr) {
   return Colors.green;
 }
 
-/// Convierte un codePoint en un [IconData] (asumiendo 'MaterialIcons')
-IconData iconFromCodePoint(String codePoint) {
-  return IconData(int.parse(codePoint), fontFamily: 'MaterialIcons');
-}


### PR DESCRIPTION
## Summary
- add `app_utils` with `iconFromCodePoint` and `hexToColor`
- reuse new helpers across widgets and screens
- remove old duplicate helpers

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684020af2bfc8329918809a1447727b1