### PR TITLE
Refactor document form widgets

### DIFF
--- a/lib/core/widgets/document_form_fields.dart
+++ b/lib/core/widgets/document_form_fields.dart
@@ -3,7 +3,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
-import 'package:ndef/ndef.dart' as ndef;
+import '../../services/nfc_service.dart';
 import '../../data/models/category.dart';
 //import 'add_category_dialog.dart';
 import 'location_dialog.dart';
@@ -28,6 +28,7 @@ class DocumentFormFields extends StatefulWidget {
   final Future<void> Function() onAddCategory;
   final Future<void> Function() onReload;
   final VoidCallback onReadNfc;
+  final bool isSaving;
 
   const DocumentFormFields({super.key,
     required this.titleController,
@@ -52,7 +53,8 @@ class DocumentFormFields extends StatefulWidget {
     required this.onSubmit,
     required this.onAddCategory,
     required this.onReload,
-    required this.onReadNfc});
+    required this.onReadNfc,
+    required this.isSaving});
 
   @override
   State<DocumentFormFields> createState() => _DocumentFormFieldsState();
@@ -77,44 +79,22 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
 
   Future<void> _readNfcTag() async {
     try {
-      final availability = await FlutterNfcKit.nfcAvailability;
-      if (availability != NFCAvailability.available) {
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('NFC no disponible.')),
-        );
-        return;
-      }
-
-      await FlutterNfcKit.poll(timeout: const Duration(seconds: 10));
-      final records = await FlutterNfcKit.readNDEFRecords();
-
-      String? tagText;
-      for (var record in records) {
-        if (record is ndef.TextRecord) {
-          tagText = record.text;
-          break;
-        }
-      }
-
-      await FlutterNfcKit.finish();
-
+      final id = await NfcService.readTagId();
       if (!mounted) return;
-
-      if (tagText != null && tagText.trim().isNotEmpty) {
-        widget.referenceController.text = tagText;
+      if (id != null) {
+        widget.referenceController.text = id;
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Referencia leída: \$tagText')),
+          SnackBar(content: Text('Referencia le\u00edda: ' + id)),
         );
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('No se encontró texto válido en la etiqueta.')),
+          const SnackBar(content: Text('No se pudo leer la etiqueta.')),
         );
       }
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error al leer NFC: \$e')),
+        SnackBar(content: Text('Error al leer NFC: ' + e.toString())),
       );
     }
   }
@@ -125,7 +105,9 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
       children: [
         TextFormField(
           controller: widget.titleController,
-          decoration: const InputDecoration(labelText: 'Título'),
+          decoration: const InputDecoration(labelText: 'Título*'),
+          validator: (value) =>
+              (value == null || value.isEmpty) ? 'Campo obligatorio' : null,
         ),
         Row(
           children: [
@@ -135,6 +117,7 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
                 items: widget.categories.map((cat) => DropdownMenuItem(value: cat.id, child: Text(cat.name))).toList(),
                 onChanged: widget.onCategoryChanged,
                 decoration: const InputDecoration(labelText: 'Categoría'),
+                validator: (val) => val == null ? 'Campo obligatorio' : null,
               ),
             ),
             IconButton(
@@ -143,9 +126,36 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
             ),
           ],
         ),
-        buildLocationDropdown(context, 'Sala', 'room', widget.rooms, widget.selectedRoom, widget.onRoomChanged, widget.onReload),
-        buildLocationDropdown(context, 'Área', 'area', widget.areas, widget.selectedArea, widget.onAreaChanged, widget.onReload),
-        buildLocationDropdown(context, 'Caja', 'box', widget.boxes, widget.selectedBox, widget.onBoxChanged, widget.onReload),
+        buildLocationDropdown(
+          context,
+          'Sala',
+          'room',
+          widget.rooms,
+          widget.selectedRoom,
+          widget.onRoomChanged,
+          widget.onReload,
+          (val) => val == null ? 'Campo obligatorio' : null,
+        ),
+        buildLocationDropdown(
+          context,
+          'Área',
+          'area',
+          widget.areas,
+          widget.selectedArea,
+          widget.onAreaChanged,
+          widget.onReload,
+          (val) => val == null ? 'Campo obligatorio' : null,
+        ),
+        buildLocationDropdown(
+          context,
+          'Caja',
+          'box',
+          widget.boxes,
+          widget.selectedBox,
+          widget.onBoxChanged,
+          widget.onReload,
+          (val) => val == null ? 'Campo obligatorio' : null,
+        ),
         Row(
           children: [
             Expanded(
@@ -179,8 +189,10 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
         ),
         const SizedBox(height: 20),
         ElevatedButton(
-          onPressed: widget.onSubmit,
-          child: const Text('Guardar'),
+          onPressed: widget.isSaving ? null : widget.onSubmit,
+          child: widget.isSaving
+              ? const CircularProgressIndicator()
+              : const Text('Guardar'),
         ),
       ],
     );

--- a/lib/core/widgets/location_dialog.dart
+++ b/lib/core/widgets/location_dialog.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import '../../database/database_helper.dart';
+import '../../widgets/location_dropdown.dart';
 
 Future<bool> showAddLocationDialog(BuildContext context, String type) async {
   final controller = TextEditingController();
@@ -42,15 +43,17 @@ Widget buildLocationDropdown(
   String? selectedValue,
   void Function(String?) onChanged,
   VoidCallback onReload,
+  String? Function(String?)? validator,
 ) {
   return Row(
     children: [
       Expanded(
-        child: DropdownButtonFormField<String>(
+        child: LocationDropdown(
+          label: label,
+          options: values,
           value: selectedValue,
-          items: values.map((val) => DropdownMenuItem(value: val, child: Text(val))).toList(),
           onChanged: onChanged,
-          decoration: InputDecoration(labelText: label),
+          validator: validator,
         ),
       ),
       IconButton(

--- a/lib/document_form_controllers.dart
+++ b/lib/document_form_controllers.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class DocumentFormControllers {
+  final title = TextEditingController();
+  final note = TextEditingController();
+  final reference = TextEditingController();
+  final date = TextEditingController();
+  final reminder = TextEditingController();
+}
+

--- a/lib/screens/add_edit_document_screen.dart
+++ b/lib/screens/add_edit_document_screen.dart
@@ -17,15 +17,23 @@ class _AddEditDocumentScreenState extends State<AddEditDocumentScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.existingDocument == null ? 'Añadir Documento' : 'Editar Documento'),
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: AddEditDocumentForm(
-          existingDocument: widget.existingDocument,
-          onSaved: () => Navigator.pop(context, true),
-        ),
+      appBar: _buildAppBar(),
+      body: _buildForm(),
+    );
+  }
+
+  PreferredSizeWidget _buildAppBar() {
+    return AppBar(
+      title: Text(widget.existingDocument == null ? 'Añadir Documento' : 'Editar Documento'),
+    );
+  }
+
+  Widget _buildForm() {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: AddEditDocumentForm(
+        existingDocument: widget.existingDocument,
+        onSaved: () => Navigator.pop(context, true),
       ),
     );
   }

--- a/lib/services/nfc_service.dart
+++ b/lib/services/nfc_service.dart
@@ -1,31 +1,20 @@
-// lib/services/nfc_service.dart
-
 import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
 
+class NfcReadException implements Exception {
+  final String message;
+  NfcReadException(this.message);
+  @override
+  String toString() => message;
+}
+
 class NfcService {
-  /// Lee una etiqueta NFC y devuelve su ID o lanza una excepción si falla.
-  Future<String?> readNfcId() async {
+  static Future<String?> readTagId() async {
     try {
-      final tag = await FlutterNfcKit.poll(timeout: const Duration(seconds: 10));
+      final tag = await FlutterNfcKit.poll();
       await FlutterNfcKit.finish();
       return tag.id;
     } catch (e) {
-      return Future.error('Error al leer NFC: \$e');
+      throw NfcReadException(e.toString());
     }
-  }
-
-  /// Verifica si el dispositivo soporta y tiene activado el NFC.
-  Future<bool> isNfcAvailable() async {
-    final availability = await FlutterNfcKit.nfcAvailability;
-    return availability == NFCAvailability.available;
-  }
-
-  /// Devuelve un mensaje descriptivo si NFC no está disponible
-  Future<String?> getAvailabilityMessage() async {
-    final availability = await FlutterNfcKit.nfcAvailability;
-    return {
-      NFCAvailability.disabled: 'NFC está desactivado. Actívalo desde los ajustes.',
-      NFCAvailability.not_supported: 'Este dispositivo no soporta NFC.',
-    }[availability];
   }
 }

--- a/lib/widgets/location_dropdown.dart
+++ b/lib/widgets/location_dropdown.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class LocationDropdown extends StatelessWidget {
+  final String label;
+  final List<String> options;
+  final String? value;
+  final ValueChanged<String?> onChanged;
+  final String? Function(String?)? validator;
+
+  const LocationDropdown({
+    super.key,
+    required this.label,
+    required this.options,
+    required this.value,
+    required this.onChanged,
+    this.validator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonFormField<String>(
+      value: value,
+      items: options
+          .map((opt) => DropdownMenuItem(value: opt, child: Text(opt)))
+          .toList(),
+      onChanged: onChanged,
+      validator: validator,
+      decoration: InputDecoration(labelText: label),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract `LocationDropdown` widget and `DocumentFormControllers`
- add `NfcService` and use in `DocumentFormFields`
- simplify `AddEditDocumentForm` with form key, controllers and loading state
- add validators for required fields
- break down `AddEditDocumentScreen` build method

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409e14c0388329baec0f94e36d50b5