### PR TITLE
Fix double submit on save

### DIFF
--- a/lib/core/widgets/add_edit_document_form.dart
+++ b/lib/core/widgets/add_edit_document_form.dart
@@ -90,7 +90,8 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
   }
 
   Future<void> _saveDocument() async {
-    if (!_formKey.currentState!.validate() ||
+    if (_isSaving ||
+        !_formKey.currentState!.validate() ||
         selectedCategoryId == null ||
         selectedRoom == null ||
         selectedArea == null ||
@@ -125,7 +126,7 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
       await DatabaseHelper().updateDocument(doc);
     }
 
-    setState(() => _isSaving = false);
+    if (mounted) setState(() => _isSaving = false);
     widget.onSaved?.call();
   }
 


### PR DESCRIPTION
## Summary
- prevent duplicate save operations in AddEditDocumentForm by checking `_isSaving`
- ensure state update only occurs while widget is mounted

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c59c4bc48329a0ca79e80facee65