### PR TITLE
Refactor NFC logic into service

### DIFF
--- a/lib/screens/nfc_scan_screen.dart
+++ b/lib/screens/nfc_scan_screen.dart
@@ -1,8 +1,7 @@
 // lib/screens/nfc_scan_screen.dart
 
 import 'package:flutter/material.dart';
-import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
-import 'package:ndef/ndef.dart' as ndef;
+import '../services/nfc_service.dart';
 import '../data/models/document.dart';
 import '../database/database_helper.dart';
 import '../data/models/category.dart';
@@ -39,28 +38,7 @@ class _NfcScanScreenState extends State<NfcScanScreen> {
     });
 
     try {
-      final availability = await FlutterNfcKit.nfcAvailability;
-      if (availability != NFCAvailability.available) {
-        if (!mounted) return;
-        setState(() {
-          error = 'NFC no disponible en este dispositivo.';
-          scanning = false;
-        });
-        return;
-      }
-
-      await FlutterNfcKit.poll(timeout: const Duration(seconds: 10));
-      final records = await FlutterNfcKit.readNDEFRecords();
-
-      String? tagText;
-      for (var record in records) {
-        if (record is ndef.TextRecord) {
-          tagText = record.text;
-          break;
-        }
-      }
-
-      await FlutterNfcKit.finish();
+      final tagText = await NfcService.readNdefText();
 
       if (!mounted) return;
 

--- a/lib/services/nfc_service.dart
+++ b/lib/services/nfc_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_nfc_kit/flutter_nfc_kit.dart';
+import 'package:ndef/ndef.dart' as ndef;
 
 class NfcService {
   static Future<String?> readTag() async {
@@ -7,6 +8,35 @@ class NfcService {
       await FlutterNfcKit.finish();
       return tag.id;
     } catch (e) {
+      throw 'Error leyendo NFC: $e';
+    }
+  }
+
+  /// Reads the first NDEF text record from a tag, if available.
+  static Future<String?> readNdefText() async {
+    try {
+      final availability = await FlutterNfcKit.nfcAvailability;
+      if (availability != NFCAvailability.available) {
+        throw 'NFC no disponible en este dispositivo.';
+      }
+
+      await FlutterNfcKit.poll(timeout: const Duration(seconds: 10));
+      final records = await FlutterNfcKit.readNDEFRecords();
+
+      String? text;
+      for (final record in records) {
+        if (record is ndef.TextRecord) {
+          text = record.text;
+          break;
+        }
+      }
+
+      await FlutterNfcKit.finish();
+      return text;
+    } catch (e) {
+      try {
+        await FlutterNfcKit.finish();
+      } catch (_) {}
       throw 'Error leyendo NFC: $e';
     }
   }


### PR DESCRIPTION
## Summary
- centralize NFC logic in `NfcService`
- update NFC scan screen to use the new service

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9fda2f08329adedd30a04ab21e3