### PR TITLE
Refactor to repository pattern

### DIFF
--- a/lib/core/widgets/add_category_dialog.dart
+++ b/lib/core/widgets/add_category_dialog.dart
@@ -3,7 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:docudex/data/models/category.dart';
-import 'package:docudex/database/database_helper.dart';
+import 'package:docudex/domain/repositories/category_repository.dart';
+import 'package:docudex/injection_container.dart';
 
 final List<IconData> availableIcons = [
   Icons.folder,
@@ -117,7 +118,7 @@ Future<bool> showAddCategoryDialog(BuildContext context) async {
       colorHex: hex,
       iconName: selectedIcon.codePoint.toString(),
     );
-    await DatabaseHelper().insertCategory(newCat);
+    await getIt<CategoryRepository>().insertCategory(newCat);
     return true;
   }
 

--- a/lib/core/widgets/add_edit_document_form.dart
+++ b/lib/core/widgets/add_edit_document_form.dart
@@ -7,7 +7,10 @@ import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path;
 import '../../data/models/document.dart';
 import '../../data/models/category.dart';
-import '../../database/database_helper.dart';
+import '../../domain/repositories/document_repository.dart';
+import '../../domain/repositories/category_repository.dart';
+import '../../domain/repositories/location_repository.dart';
+import '../../injection_container.dart';
 import 'document_form_fields.dart';
 import 'add_category_dialog.dart';
 import '../../document_form_controllers.dart';
@@ -41,10 +44,10 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
   }
 
   Future<void> _loadData() async {
-    final cats = await DatabaseHelper().getCategories();
-    final r = await DatabaseHelper().getLocationValues('room');
-    final a = await DatabaseHelper().getLocationValues('area');
-    final b = await DatabaseHelper().getLocationValues('box');
+    final cats = await getIt<CategoryRepository>().getCategories();
+    final r = await getIt<LocationRepository>().getLocationValues('room');
+    final a = await getIt<LocationRepository>().getLocationValues('area');
+    final b = await getIt<LocationRepository>().getLocationValues('box');
 
     if (!mounted) return;
 
@@ -121,9 +124,9 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
     );
 
     if (widget.existingDocument == null) {
-      await DatabaseHelper().insertDocument(doc);
+      await getIt<DocumentRepository>().insertDocument(doc);
     } else {
-      await DatabaseHelper().updateDocument(doc);
+      await getIt<DocumentRepository>().updateDocument(doc);
     }
 
     if (mounted) setState(() => _isSaving = false);

--- a/lib/core/widgets/location_dialog.dart
+++ b/lib/core/widgets/location_dialog.dart
@@ -1,8 +1,9 @@
 // lib/widgets/location_dialog.dart
 
 import 'package:flutter/material.dart';
-import '../../database/database_helper.dart';
+import '../../domain/repositories/location_repository.dart';
 import '../../widgets/location_dropdown.dart';
+import '../../injection_container.dart';
 
 Future<bool> showAddLocationDialog(BuildContext context, String type) async {
   final controller = TextEditingController();
@@ -29,7 +30,7 @@ Future<bool> showAddLocationDialog(BuildContext context, String type) async {
   );
 
   if (result != null && result.isNotEmpty) {
-    await DatabaseHelper().insertLocation(type, result);
+    await getIt<LocationRepository>().insertLocation(type, result);
     return true;
   }
   return false;

--- a/lib/data/repositories/category_repository_impl.dart
+++ b/lib/data/repositories/category_repository_impl.dart
@@ -1,0 +1,29 @@
+import '../../database/database_helper.dart';
+import '../models/category.dart';
+import '../../domain/repositories/category_repository.dart';
+
+class CategoryRepositoryImpl implements CategoryRepository {
+  final DatabaseHelper databaseHelper;
+
+  CategoryRepositoryImpl({required this.databaseHelper});
+
+  @override
+  Future<int> deleteCategory(int id) {
+    return databaseHelper.deleteCategory(id);
+  }
+
+  @override
+  Future<List<Category>> getCategories() {
+    return databaseHelper.getCategories();
+  }
+
+  @override
+  Future<int> insertCategory(Category category) {
+    return databaseHelper.insertCategory(category);
+  }
+
+  @override
+  Future<int> updateCategory(Category category) {
+    return databaseHelper.updateCategory(category);
+  }
+}

--- a/lib/data/repositories/location_repository_impl.dart
+++ b/lib/data/repositories/location_repository_impl.dart
@@ -1,0 +1,18 @@
+import '../../database/database_helper.dart';
+import '../../domain/repositories/location_repository.dart';
+
+class LocationRepositoryImpl implements LocationRepository {
+  final DatabaseHelper databaseHelper;
+
+  LocationRepositoryImpl({required this.databaseHelper});
+
+  @override
+  Future<void> insertLocation(String type, String value) {
+    return databaseHelper.insertLocation(type, value);
+  }
+
+  @override
+  Future<List<String>> getLocationValues(String type) {
+    return databaseHelper.getLocationValues(type);
+  }
+}

--- a/lib/domain/repositories/category_repository.dart
+++ b/lib/domain/repositories/category_repository.dart
@@ -1,0 +1,8 @@
+import '../../data/models/category.dart';
+
+abstract class CategoryRepository {
+  Future<int> insertCategory(Category category);
+  Future<List<Category>> getCategories();
+  Future<int> updateCategory(Category category);
+  Future<int> deleteCategory(int id);
+}

--- a/lib/domain/repositories/location_repository.dart
+++ b/lib/domain/repositories/location_repository.dart
@@ -1,0 +1,4 @@
+abstract class LocationRepository {
+  Future<void> insertLocation(String type, String value);
+  Future<List<String>> getLocationValues(String type);
+}

--- a/lib/domain/usecases/get_categories.dart
+++ b/lib/domain/usecases/get_categories.dart
@@ -1,0 +1,10 @@
+import '../../data/models/category.dart';
+import '../repositories/category_repository.dart';
+
+class GetCategories {
+  final CategoryRepository repository;
+
+  const GetCategories(this.repository);
+
+  Future<List<Category>> call() => repository.getCategories();
+}

--- a/lib/injection_container.dart
+++ b/lib/injection_container.dart
@@ -2,8 +2,13 @@ import 'package:get_it/get_it.dart';
 
 import 'database/database_helper.dart';
 import 'data/repositories/document_repository_impl.dart';
+import 'data/repositories/category_repository_impl.dart';
+import 'data/repositories/location_repository_impl.dart';
 import 'domain/usecases/get_documents.dart';
+import 'domain/usecases/get_categories.dart';
 import 'domain/repositories/document_repository.dart';
+import 'domain/repositories/category_repository.dart';
+import 'domain/repositories/location_repository.dart';
 
 final getIt = GetIt.instance;
 
@@ -12,5 +17,12 @@ void setupDependencies() {
   getIt.registerLazySingleton<DocumentRepository>(
     () => DocumentRepositoryImpl(databaseHelper: getIt()),
   );
+  getIt.registerLazySingleton<CategoryRepository>(
+    () => CategoryRepositoryImpl(databaseHelper: getIt()),
+  );
+  getIt.registerLazySingleton<LocationRepository>(
+    () => LocationRepositoryImpl(databaseHelper: getIt()),
+  );
   getIt.registerFactory(() => GetDocuments(getIt()));
+  getIt.registerFactory(() => GetCategories(getIt()));
 }

--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -3,7 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import '../data/models/category.dart';
-import '../database/database_helper.dart';
+import '../domain/repositories/category_repository.dart';
+import '../injection_container.dart';
 import '../utils/app_utils.dart';
 import '../utils/icon_utils.dart';
 
@@ -34,7 +35,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen> {
   }
 
   Future<void> _loadCategories() async {
-    final cats = await DatabaseHelper().getCategories();
+    final cats = await getIt<CategoryRepository>().getCategories();
     setState(() {
       categories = cats;
     });
@@ -102,7 +103,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen> {
         colorHex: hex,
         iconName: selectedIcon.codePoint.toString(),
       );
-      await DatabaseHelper().insertCategory(newCat);
+      await getIt<CategoryRepository>().insertCategory(newCat);
       _loadCategories();
     }
   }
@@ -120,7 +121,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen> {
       ),
     );
     if (confirm == true) {
-      await DatabaseHelper().deleteCategory(id);
+      await getIt<CategoryRepository>().deleteCategory(id);
       _loadCategories();
     }
   }

--- a/lib/screens/document_detail_screen.dart
+++ b/lib/screens/document_detail_screen.dart
@@ -4,7 +4,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import '../data/models/document.dart';
 import '../data/models/category.dart';
-import '../database/database_helper.dart';
+import '../domain/repositories/document_repository.dart';
+import '../injection_container.dart';
 import '../utils/app_utils.dart';
 import '../utils/icon_utils.dart';
 import '../utils/document_utils.dart';
@@ -54,7 +55,7 @@ class DocumentDetailScreen extends StatelessWidget {
                 ),
               );
               if (confirm == true) {
-                await DatabaseHelper().deleteDocument(document.id!);
+                await getIt<DocumentRepository>().deleteDocument(document.id!);
                 if (context.mounted) Navigator.pop(context, true);
               }
             },

--- a/lib/screens/document_list_screen.dart
+++ b/lib/screens/document_list_screen.dart
@@ -5,9 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import '../data/models/document.dart';
 import '../data/models/category.dart';
-import '../database/database_helper.dart';
 import '../injection_container.dart';
 import '../domain/usecases/get_documents.dart';
+import '../domain/repositories/category_repository.dart';
 import '../services/backup_service.dart';
 import '../core/widgets/document_card.dart';
 import '../core/widgets/search_bar.dart';
@@ -44,7 +44,7 @@ class _DocumentListScreenState extends State<DocumentListScreen> {
 
   Future<void> _loadData() async {
     final docs = await getIt<GetDocuments>()();
-    final cats = await DatabaseHelper().getCategories();
+    final cats = await getIt<CategoryRepository>().getCategories();
     setState(() {
       documents = docs;
       categories = cats;

--- a/lib/screens/nfc_scan_screen.dart
+++ b/lib/screens/nfc_scan_screen.dart
@@ -3,8 +3,10 @@
 import 'package:flutter/material.dart';
 import '../services/nfc_service.dart';
 import '../data/models/document.dart';
-import '../database/database_helper.dart';
 import '../data/models/category.dart';
+import '../domain/repositories/document_repository.dart';
+import '../domain/repositories/category_repository.dart';
+import '../injection_container.dart';
 import '../utils/app_utils.dart';
 import '../utils/icon_utils.dart';
 import 'document_detail_screen.dart';
@@ -50,8 +52,8 @@ class _NfcScanScreenState extends State<NfcScanScreen> {
         return;
       }
 
-      final docs = await DatabaseHelper().getDocuments();
-      final cats = await DatabaseHelper().getCategories();
+      final docs = await getIt<DocumentRepository>().getDocuments();
+      final cats = await getIt<CategoryRepository>().getCategories();
 
       final matches = docs.where((doc) => doc.referenceNumber == tagText).toList();
 

--- a/lib/services/backup_service.dart
+++ b/lib/services/backup_service.dart
@@ -4,11 +4,12 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 import '../data/models/document.dart';
-import '../database/database_helper.dart';
+import '../domain/repositories/document_repository.dart';
+import '../injection_container.dart';
 
 class BackupService {
   Future<String> exportToJson() async {
-    final documents = await DatabaseHelper().getDocuments();
+    final documents = await getIt<DocumentRepository>().getDocuments();
     final jsonList = documents.map((doc) => doc.toMap()).toList();
     final jsonString = jsonEncode(jsonList);
 
@@ -25,7 +26,7 @@ class BackupService {
     int importedCount = 0;
     for (final item in jsonList) {
       final doc = Document.fromMap(item);
-      await DatabaseHelper().insertDocument(doc);
+      await getIt<DocumentRepository>().insertDocument(doc);
       importedCount++;
     }
 


### PR DESCRIPTION
## Summary
- add repositories for categories and locations
- wire category/location repositories in injection container
- switch widgets and screens to use repositories instead of `DatabaseHelper`
- update backup service to use injected `DocumentRepository`

## Testing
- `Codex couldn't run certain commands due to environnment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6840cdfc0d5483298f0f0d08d1dd46e4