### PR TITLE
Add reusable form widgets

### DIFF
--- a/lib/core/widgets/add_edit_document_form.dart
+++ b/lib/core/widgets/add_edit_document_form.dart
@@ -9,7 +9,6 @@ import '../../data/models/document.dart';
 import '../../data/models/category.dart';
 import '../../domain/repositories/document_repository.dart';
 import '../../domain/repositories/category_repository.dart';
-import '../../domain/repositories/location_repository.dart';
 import '../../injection_container.dart';
 import 'document_form_fields.dart';
 import 'add_category_dialog.dart';
@@ -31,7 +30,6 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
   bool _isSaving = false;
 
   List<Category> categories = [];
-  List<String> rooms = [], areas = [], boxes = [];
   int? selectedCategoryId;
   String? selectedRoom, selectedArea, selectedBox;
   bool isPrivate = false;
@@ -45,17 +43,10 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
 
   Future<void> _loadData() async {
     final cats = await getIt<CategoryRepository>().getCategories();
-    final r = await getIt<LocationRepository>().getLocationValues('room');
-    final a = await getIt<LocationRepository>().getLocationValues('area');
-    final b = await getIt<LocationRepository>().getLocationValues('box');
-
     if (!mounted) return;
 
     setState(() {
       categories = cats;
-      rooms = r;
-      areas = a;
-      boxes = b;
 
       final doc = widget.existingDocument;
       if (doc != null) {
@@ -157,9 +148,6 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
           reminderController: _controllers.reminder,
           isSaving: _isSaving,
           categories: categories,
-          rooms: rooms,
-          areas: areas,
-          boxes: boxes,
           selectedCategoryId: selectedCategoryId,
           selectedRoom: selectedRoom,
           selectedArea: selectedArea,
@@ -172,7 +160,6 @@ class _AddEditDocumentFormState extends State<AddEditDocumentForm> {
           onPrivateChanged: (val) => setState(() => isPrivate = val),
           onSubmit: _saveDocument,
           onAddCategory: _addCategory,
-          onReload: _loadData,
           onReadNfc: () {},
         ),
         const SizedBox(height: 20),

--- a/lib/core/widgets/document_form_fields.dart
+++ b/lib/core/widgets/document_form_fields.dart
@@ -4,10 +4,11 @@ import 'package:flutter/material.dart';
 import '../../services/nfc_service.dart';
 import '../../data/models/category.dart';
 //import 'add_category_dialog.dart';
-import 'location_dialog.dart';
+
 import '../../widgets/labeled_text_field.dart';
 import '../../widgets/date_picker_field.dart';
 import '../../widgets/category_selector.dart';
+import '../../widgets/location_dropdown.dart';
 
 class DocumentFormFields extends StatefulWidget {
   final TextEditingController titleController;
@@ -16,7 +17,6 @@ class DocumentFormFields extends StatefulWidget {
   final TextEditingController dateController;
   final TextEditingController reminderController;
   final List<Category> categories;
-  final List<String> rooms, areas, boxes;
   final int? selectedCategoryId;
   final String? selectedRoom, selectedArea, selectedBox;
   final bool isPrivate;
@@ -27,7 +27,6 @@ class DocumentFormFields extends StatefulWidget {
   final void Function(bool) onPrivateChanged;
   final VoidCallback onSubmit;
   final Future<void> Function() onAddCategory;
-  final Future<void> Function() onReload;
   final VoidCallback onReadNfc;
   final bool isSaving;
 
@@ -38,9 +37,6 @@ class DocumentFormFields extends StatefulWidget {
     required this.dateController,
     required this.reminderController,
     required this.categories,
-    required this.rooms,
-    required this.areas,
-    required this.boxes,
     required this.selectedCategoryId,
     required this.selectedRoom,
     required this.selectedArea,
@@ -53,7 +49,6 @@ class DocumentFormFields extends StatefulWidget {
     required this.onPrivateChanged,
     required this.onSubmit,
     required this.onAddCategory,
-    required this.onReload,
     required this.onReadNfc,
     required this.isSaving});
 
@@ -91,9 +86,8 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
       children: [
         LabeledTextField(
           controller: widget.titleController,
-          label: 'Título*',
-          validator: (value) =>
-              (value == null || value.isEmpty) ? 'Campo obligatorio' : null,
+          label: 'Título',
+          isRequired: true,
         ),
         CategorySelector(
           categories: widget.categories,
@@ -101,35 +95,23 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
           onChanged: widget.onCategoryChanged,
           onAdd: widget.onAddCategory,
         ),
-        buildLocationDropdown(
-          context,
-          'Sala',
-          'room',
-          widget.rooms,
-          widget.selectedRoom,
-          widget.onRoomChanged,
-          widget.onReload,
-          (val) => val == null ? 'Campo obligatorio' : null,
+        LocationDropdown(
+          type: 'room',
+          value: widget.selectedRoom,
+          onChanged: widget.onRoomChanged,
+          validator: (val) => val == null ? 'Campo obligatorio' : null,
         ),
-        buildLocationDropdown(
-          context,
-          'Área',
-          'area',
-          widget.areas,
-          widget.selectedArea,
-          widget.onAreaChanged,
-          widget.onReload,
-          (val) => val == null ? 'Campo obligatorio' : null,
+        LocationDropdown(
+          type: 'area',
+          value: widget.selectedArea,
+          onChanged: widget.onAreaChanged,
+          validator: (val) => val == null ? 'Campo obligatorio' : null,
         ),
-        buildLocationDropdown(
-          context,
-          'Caja',
-          'box',
-          widget.boxes,
-          widget.selectedBox,
-          widget.onBoxChanged,
-          widget.onReload,
-          (val) => val == null ? 'Campo obligatorio' : null,
+        LocationDropdown(
+          type: 'box',
+          value: widget.selectedBox,
+          onChanged: widget.onBoxChanged,
+          validator: (val) => val == null ? 'Campo obligatorio' : null,
         ),
         Row(
           children: [
@@ -137,8 +119,7 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
               child: LabeledTextField(
                 controller: widget.referenceController,
                 label: 'Nº de referencia (NFC)',
-                validator: (value) =>
-                    (value == null || value.isEmpty) ? 'Campo obligatorio' : null,
+                isRequired: true,
               ),
             ),
             IconButton(icon: const Icon(Icons.nfc), onPressed: _readNfcTag),
@@ -147,21 +128,15 @@ class _DocumentFormFieldsState extends State<DocumentFormFields> {
         LabeledTextField(
           controller: widget.noteController,
           label: 'Nota (opcional)',
-          validator: (value) =>
-              (value == null || value.isEmpty) ? 'Campo obligatorio' : null,
         ),
         DatePickerField(
           controller: widget.dateController,
           label: 'Fecha de caducidad (opcional)',
-          validator: (value) =>
-              (value == null || value.isEmpty) ? 'Campo obligatorio' : null,
         ),
         LabeledTextField(
           controller: widget.reminderController,
           label: 'Recordatorio días antes (opcional)',
           keyboardType: TextInputType.number,
-          validator: (value) =>
-              (value == null || value.isEmpty) ? 'Campo obligatorio' : null,
         ),
         SwitchListTile(
           value: widget.isPrivate,

--- a/lib/core/widgets/location_dialog.dart
+++ b/lib/core/widgets/location_dialog.dart
@@ -2,7 +2,6 @@
 
 import 'package:flutter/material.dart';
 import '../../domain/repositories/location_repository.dart';
-import '../../widgets/location_dropdown.dart';
 import '../../injection_container.dart';
 
 Future<bool> showAddLocationDialog(BuildContext context, String type) async {
@@ -34,36 +33,4 @@ Future<bool> showAddLocationDialog(BuildContext context, String type) async {
     return true;
   }
   return false;
-}
-
-Widget buildLocationDropdown(
-  BuildContext context,
-  String label,
-  String type,
-  List<String> values,
-  String? selectedValue,
-  void Function(String?) onChanged,
-  VoidCallback onReload,
-  String? Function(String?)? validator,
-) {
-  return Row(
-    children: [
-      Expanded(
-        child: LocationDropdown(
-          label: label,
-          options: values,
-          value: selectedValue,
-          onChanged: onChanged,
-          validator: validator,
-        ),
-      ),
-      IconButton(
-        icon: const Icon(Icons.add),
-        onPressed: () async {
-          final added = await showAddLocationDialog(context, type);
-          if (added) onReload();
-        },
-      ),
-    ],
-  );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@
 import 'package:flutter/material.dart';
 import 'screens/document_list_screen.dart';
 import 'injection_container.dart';
+import 'package:provider/provider.dart';
+import 'providers/location_provider.dart';
 
 void main() {
   setupDependencies();
@@ -10,17 +12,22 @@ void main() {
 
 class ArchivoCentralApp extends StatelessWidget {
   const ArchivoCentralApp({super.key});
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Archivo Central',
-      theme: ThemeData.dark().copyWith(
-        primaryColor: Colors.blueGrey,
-        scaffoldBackgroundColor: Colors.black,
-        cardColor: Colors.grey[900],
-        textTheme: const TextTheme(bodyMedium: TextStyle(color: Colors.white70)),
+    return ChangeNotifierProvider(
+      create: (_) => LocationProvider(),
+      child: MaterialApp(
+        title: 'Archivo Central',
+        theme: ThemeData.dark().copyWith(
+          primaryColor: Colors.blueGrey,
+          scaffoldBackgroundColor: Colors.black,
+          cardColor: Colors.grey[900],
+          textTheme:
+              const TextTheme(bodyMedium: TextStyle(color: Colors.white70)),
+        ),
+        home: const DocumentListScreen(),
       ),
-      home: const DocumentListScreen(),
     );
   }
 }

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+import '../domain/repositories/location_repository.dart';
+import '../injection_container.dart';
+
+class LocationProvider extends ChangeNotifier {
+  final LocationRepository _repository = getIt<LocationRepository>();
+
+  final Map<String, List<String>> _data = {
+    'room': [],
+    'area': [],
+    'box': [],
+  };
+
+  LocationProvider() {
+    _load('room');
+    _load('area');
+    _load('box');
+  }
+
+  List<String> getByType(String type) => _data[type] ?? [];
+
+  Future<void> reload(String type) => _load(type);
+
+  Future<void> _load(String type) async {
+    _data[type] = await _repository.getLocationValues(type);
+    notifyListeners();
+  }
+
+  Future<void> add(String type, String value) async {
+    await _repository.insertLocation(type, value);
+    await _load(type);
+  }
+}

--- a/lib/widgets/labeled_text_field.dart
+++ b/lib/widgets/labeled_text_field.dart
@@ -1,33 +1,41 @@
 import 'package:flutter/material.dart';
 
 class LabeledTextField extends StatelessWidget {
-  final TextEditingController controller;
+  final TextEditingController? controller;
   final String label;
-  final String? Function(String?)? validator;
+  final String? hint;
+  final bool isRequired;
+  final TextInputType? keyboardType;
   final bool readOnly;
   final VoidCallback? onTap;
-  final TextInputType? keyboardType;
 
   const LabeledTextField({
     super.key,
-    required this.controller,
+    this.controller,
     required this.label,
-    this.validator,
+    this.hint,
+    this.isRequired = false,
+    this.keyboardType,
     this.readOnly = false,
     this.onTap,
-    this.keyboardType,
   });
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
       controller: controller,
-      decoration: InputDecoration(labelText: label),
-      validator: validator,
-      autovalidateMode: AutovalidateMode.onUserInteraction,
+      decoration: InputDecoration(
+        labelText: label + (isRequired ? '*' : ''),
+        hintText: hint,
+      ),
+      validator: isRequired
+          ? (value) => value == null || value.isEmpty
+              ? '$label es obligatorio'
+              : null
+          : null,
+      keyboardType: keyboardType,
       readOnly: readOnly,
       onTap: onTap,
-      keyboardType: keyboardType,
     );
   }
 }

--- a/lib/widgets/location_dropdown.dart
+++ b/lib/widgets/location_dropdown.dart
@@ -1,31 +1,53 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../core/widgets/location_dialog.dart';
+import '../providers/location_provider.dart';
 
 class LocationDropdown extends StatelessWidget {
-  final String label;
-  final List<String> options;
+  final String type; // 'room', 'area', 'box'
   final String? value;
   final ValueChanged<String?> onChanged;
-  final String? Function(String?)? validator;
+  final FormFieldValidator<String>? validator;
+  final bool showAddButton;
 
   const LocationDropdown({
     super.key,
-    required this.label,
-    required this.options,
-    required this.value,
+    required this.type,
     required this.onChanged,
+    this.value,
     this.validator,
+    this.showAddButton = true,
   });
 
   @override
   Widget build(BuildContext context) {
+    final locations = context.watch<LocationProvider>().getByType(type);
+
     return DropdownButtonFormField<String>(
       value: value,
-      items: options
-          .map((opt) => DropdownMenuItem(value: opt, child: Text(opt)))
+      items: locations
+          .map((loc) => DropdownMenuItem(value: loc, child: Text(loc)))
           .toList(),
       onChanged: onChanged,
       validator: validator,
-      decoration: InputDecoration(labelText: label),
+      decoration: InputDecoration(
+        labelText: 'Ubicación - ${_capitalize(type)}',
+        suffixIcon: showAddButton
+            ? IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: () async {
+                  final provider = context.read<LocationProvider>();
+                  final added = await showAddLocationDialog(context, type);
+                  if (added) provider.reload(type);
+                },
+              )
+            : null,
+      ),
     );
   }
+
+  String _capitalize(String str) => str.isEmpty
+      ? str
+      : str[0].toUpperCase() + str.substring(1).toLowerCase();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   collection: any
   image_picker: any
   get_it: any
+  provider: any
   
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- create LocationProvider for shared location data
- redesign LocationDropdown to fetch data from provider
- extend LabeledTextField with validation helpers
- refactor DocumentFormFields to use new widgets
- update AddEditDocumentForm and app entry to wire provider

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840d5104ad883299061ead769b199cb