### PR TITLE
Dispose search controller

### DIFF
--- a/lib/screens/document_list_screen.dart
+++ b/lib/screens/document_list_screen.dart
@@ -256,4 +256,10 @@ class _DocumentListScreenState extends State<DocumentListScreen> {
       ),
     );
   }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
 }


### PR DESCRIPTION
## Summary
- dispose the search TextEditingController

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dcdbcafc8329a8ec4d4f4ce0af71