### PR TITLE
Fix duplicate category lookup

### DIFF
--- a/lib/screens/document_list_screen.dart
+++ b/lib/screens/document_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import '../data/models/document.dart';
 import '../data/models/category.dart';
+import '../utils/category_utils.dart';
 import '../injection_container.dart';
 import '../domain/usecases/get_documents.dart';
 import '../domain/repositories/category_repository.dart';
@@ -108,12 +109,6 @@ class _DocumentListScreenState extends State<DocumentListScreen> {
         (urgencyFilter == 'expired' && diff < 0);
   }
 
-  Category _getCategory(int categoryId) {
-    return categories.firstWhere(
-      (cat) => cat.id == categoryId,
-      orElse: () => Category(name: 'Sin categoría', colorHex: '#666666', iconName: '0xe2c7'),
-    );
-  }
 
   void _navigateToAddDocument() async {
     final result = await Navigator.push(
@@ -132,7 +127,7 @@ class _DocumentListScreenState extends State<DocumentListScreen> {
   }
 
   void _navigateToDetail(Document doc) async {
-    final cat = _getCategory(doc.categoryId);
+    final cat = getCategoryById(categories, doc.categoryId);
     final result = await Navigator.push(
       context,
       MaterialPageRoute(
@@ -216,7 +211,7 @@ class _DocumentListScreenState extends State<DocumentListScreen> {
                     itemCount: filteredDocuments.length,
                     itemBuilder: (context, index) {
                       final doc = filteredDocuments[index];
-                      final cat = _getCategory(doc.categoryId);
+                      final cat = getCategoryById(categories, doc.categoryId);
                       return DocumentCard(
                         document: doc,
                         categoryName: cat.name,

--- a/lib/screens/nfc_scan_screen.dart
+++ b/lib/screens/nfc_scan_screen.dart
@@ -9,6 +9,7 @@ import '../domain/repositories/category_repository.dart';
 import '../injection_container.dart';
 import '../utils/app_utils.dart';
 import '../utils/icon_utils.dart';
+import '../utils/category_utils.dart';
 import 'document_detail_screen.dart';
 import '../widgets/shared/custom_app_bar.dart';
 import '../widgets/shared/empty_state.dart';
@@ -74,12 +75,6 @@ class _NfcScanScreenState extends State<NfcScanScreen> {
     }
   }
 
-  Category _getCategory(int categoryId) {
-    return categories.firstWhere(
-      (cat) => cat.id == categoryId,
-      orElse: () => Category(name: 'Sin categoría', colorHex: '#666666', iconName: '0xe2c7'),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -105,7 +100,7 @@ class _NfcScanScreenState extends State<NfcScanScreen> {
                               itemCount: matchedDocs.length,
                               itemBuilder: (context, index) {
                                 final doc = matchedDocs[index];
-                                final cat = _getCategory(doc.categoryId);
+                                final cat = getCategoryById(categories, doc.categoryId);
                                 return ListTile(
                                   leading: CircleAvatar(
                                     backgroundColor: hexToColor(cat.colorHex),

--- a/lib/utils/category_utils.dart
+++ b/lib/utils/category_utils.dart
@@ -1,0 +1,13 @@
+import '../data/models/category.dart';
+
+/// Returns the matching [Category] by id or a default placeholder.
+Category getCategoryById(List<Category> categories, int id) {
+  return categories.firstWhere(
+    (cat) => cat.id == id,
+    orElse: () => Category(
+      name: 'Sin categoría',
+      colorHex: '#666666',
+      iconName: '0xe2c7',
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- move category lookup to a new utility
- use helper in document and NFC screens

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dda4f9cc8329b7e550dc81ab369e