### PR TITLE
Fix missing consts and dispose controllers

### DIFF
--- a/lib/core/widgets/add_category_dialog.dart
+++ b/lib/core/widgets/add_category_dialog.dart
@@ -103,6 +103,7 @@ Future<bool> showAddCategoryDialog(BuildContext context) async {
       ),
     ),
   );
+  nameController.dispose();
 
   if (result == true && nameController.text.trim().isNotEmpty) {
     final hex = '#'

--- a/lib/core/widgets/location_dialog.dart
+++ b/lib/core/widgets/location_dialog.dart
@@ -27,6 +27,7 @@ Future<bool> showAddLocationDialog(BuildContext context, String type) async {
       ],
     ),
   );
+  controller.dispose();
 
   if (result != null && result.isNotEmpty) {
     await getIt<LocationRepository>().insertLocation(type, result);

--- a/lib/core/widgets/sort_menu.dart
+++ b/lib/core/widgets/sort_menu.dart
@@ -22,26 +22,26 @@ class DocumentSortMenu extends StatelessWidget {
       icon: const Icon(Icons.sort),
       initialValue: selected,
       onSelected: onSelected,
-      itemBuilder: (context) => [
-        const PopupMenuItem(
+      itemBuilder: (context) => const [
+        PopupMenuItem(
           value: DocumentSortOption.titleAsc,
-          child: Text('Título A-Z'),
+          child: const Text('Título A-Z'),
         ),
-        const PopupMenuItem(
+        PopupMenuItem(
           value: DocumentSortOption.titleDesc,
-          child: Text('Título Z-A'),
+          child: const Text('Título Z-A'),
         ),
-        const PopupMenuItem(
+        PopupMenuItem(
           value: DocumentSortOption.dateAsc,
-          child: Text('Fecha más próxima'),
+          child: const Text('Fecha más próxima'),
         ),
-        const PopupMenuItem(
+        PopupMenuItem(
           value: DocumentSortOption.dateDesc,
-          child: Text('Fecha más lejana'),
+          child: const Text('Fecha más lejana'),
         ),
-        const PopupMenuItem(
+        PopupMenuItem(
           value: DocumentSortOption.createdDesc,
-          child: Text('Más reciente creado'),
+          child: const Text('Más reciente creado'),
         ),
       ],
     );

--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -92,6 +92,7 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen> {
         ),
       ),
     );
+    nameController.dispose();
 
     if (result == true && nameController.text.trim().isNotEmpty) {
       final hex = colorToHex(selectedColor);


### PR DESCRIPTION
## Summary
- mark sort menu label strings as const
- dispose text controllers after dialogs
- cleanup add category dialog logic

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e61aa9348329958e890a093c7705