### PR TITLE
Fix missing EmptyState import

### DIFF
--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -9,6 +9,7 @@ import '../utils/app_utils.dart';
 import '../utils/icon_utils.dart';
 import '../widgets/forms/icon_selector.dart';
 import '../widgets/shared/custom_app_bar.dart';
+import '../widgets/shared/empty_state.dart';
 
 class CategoryManagementScreen extends StatefulWidget {
   const CategoryManagementScreen({super.key});


### PR DESCRIPTION
## Summary
- import EmptyState widget in CategoryManagementScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ec5eb3a88329b20bf76468ff89ca