### PR TITLE
Fix category hex color conversion

### DIFF
--- a/lib/screens/category_management_screen.dart
+++ b/lib/screens/category_management_screen.dart
@@ -45,10 +45,10 @@ class _CategoryManagementScreenState extends State<CategoryManagementScreen> {
   }
 
   String colorToHex(Color color) {
-  return '#'
-        '${color.r.toInt().toRadixString(16).padLeft(2, '0')}'
-        '${color.g.toInt().toRadixString(16).padLeft(2, '0')}'
-        '${color.b.toInt().toRadixString(16).padLeft(2, '0')}';
+    return '#'
+        '${color.red.toRadixString(16).padLeft(2, '0')}'
+        '${color.green.toRadixString(16).padLeft(2, '0')}'
+        '${color.blue.toRadixString(16).padLeft(2, '0')}';
   }
 
 


### PR DESCRIPTION
## Summary
- fix category color to hex conversion

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415413ad4883299863aeae35c7f84f